### PR TITLE
Remove override of link rule

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,6 +1,6 @@
 CC=@CC@
 CFLAGS=@CFLAGS@
-LIBS=@LIBS@
+LDLIBS=@LIBS@
 prefix = @prefix@
 exec_prefix = @exec_prefix@
 bindir = @bindir@
@@ -14,7 +14,6 @@ all: multitime
 
 
 multitime: ${MULTITIME_OBJS}
-	${CC} -o multitime ${MULTITIME_OBJS} ${LIBS}
 
 
 install: multitime


### PR DESCRIPTION
Currently, the compile rule (.c→.o) is left as is, so it picks up
CFLAGS correctly from the environment. However, the link rule is
explicitly defined without LDFLAGS, so this prevents the nevironment
from passing custom flags.

Since the only reason for the explicit rule is to define the
dependencies on libm and the object files, do just that: declare libm
in LDLIBS (which will cause it to be passed), declare the objects
files, and drop the explicit (redundant) rule.