### PR TITLE
Use LDFLAGS in the link step

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,5 +1,6 @@
 CC=@CC@
 CFLAGS=@CFLAGS@
+LDFLAGS=@LDFLAGS@
 LIBS=@LIBS@
 prefix = @prefix@
 exec_prefix = @exec_prefix@
@@ -14,7 +15,7 @@ all: multitime
 
 
 multitime: ${MULTITIME_OBJS}
-	${CC} -o multitime ${MULTITIME_OBJS} ${LIBS}
+	${CC} ${LDFLAGS} -o multitime ${MULTITIME_OBJS} ${LIBS}
 
 
 install: multitime


### PR DESCRIPTION
This allows building with both CFLAGS and LDFLAGS customized,
e.g. for easier packaging.