### PR TITLE
Prevent tmp file leaks when using stdincmd or stdoutcmd

### DIFF
--- a/multitime.c
+++ b/multitime.c
@@ -103,6 +103,7 @@ void execute_cmd(Conf *conf, Cmd *cmd, int runi)
             outtmpf = fdopen(outtmpfd, "r+");
         if (outtmpfd == -1 || outtmpf == NULL)
             errx(1, "Can't create temporary file.");
+	unlink(outtmpp);
     }
 
     struct rusage *ru = cmd->rusages[runi] =
@@ -193,6 +194,7 @@ FILE *read_input(Conf *conf, Cmd *cmd, int runi)
         goto cmd_err;
     free(input_cmd);
     fseek(tmpf, 0, SEEK_SET);
+    unlink(tmpp);
 
     return tmpf;
 


### PR DESCRIPTION
The tmp file name can be deleted immediately after creating it
(because it will be only accessed using file descriptors).

Fixes:
```
→ ls -ltrc /tmp/mt.XXXX*
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXF608ov
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXLdWqGu
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXCv3K6t
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXCdW5Iu
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXjTeEkl
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXzAUkVk
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXM3EpBk
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXbeF1Ml
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXIMtVNm
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXF9rqwk
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXBsREzk
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXQidItn
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXVnk3Sn
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXX8Eb6hn
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXdtCLdm
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXrOTC7l
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXX2Bzt8n
-rw------- 1 juergen juergen 4  2. Aug 14:52 /tmp/mt.XXXXkerxYj
```